### PR TITLE
Feature/adiciona suporte altura em centimetros

### DIFF
--- a/CalculadoraIMC/assets/css/style.css
+++ b/CalculadoraIMC/assets/css/style.css
@@ -73,7 +73,14 @@ body {
     margin-top: 3px;
 }
 
-.input-field span,
+.input-field span {
+    color: #fd0896;
+    font-size: 1.3rem;
+    padding: 0.6rem 0.5rem;
+    width: 6rem;
+    text-align: center;
+    text-align: end;
+}
 .input-field span i {
     color: #fd0896;
     font-size: 1.3rem;
@@ -82,16 +89,18 @@ body {
 
 .input-field i.fa-weight-hanging {
     margin-left: 0.5rem;
+    font-size: 1.3rem;
 }
 
 .input-field i.fa-ruler {
     margin-left: 0.5rem;
+    font-size: 1.3rem;
 }
 
 .input-field input {
     background-color: transparent;
     border: none;
-    width: 100%;
+    width: calc(100% - 3rem);
     font-size: 1.3rem;
     color: black;
     padding: 0 0.5rem;

--- a/CalculadoraIMC/assets/js/script.js
+++ b/CalculadoraIMC/assets/js/script.js
@@ -5,7 +5,12 @@ form.addEventListener('submit', function(event) {
     event.preventDefault();
 
     const weight = document.getElementById('weight').value;
-    const height = document.getElementById('height').value;
+    let height = document.getElementById('height').value;
+
+    // Verifica se a altura está em centímetros e converte para metros, se necessário
+    if (height > 3) {
+        height = height / 100;
+    }
 
     const bmi = (weight / (height * height)).toFixed(2);
 

--- a/CalculadoraIMC/index.html
+++ b/CalculadoraIMC/index.html
@@ -28,7 +28,7 @@
 
                 <div class="input-box">
                     <label for="weight">
-                        Peso em kg
+                        Peso
                     </label>
                     <div class="input-field">
                         <i class="fa-solid fa-weight-hanging" style="color: #fd0896;"></i>
@@ -41,13 +41,13 @@
 
                 <div class="input-box">
                     <label for="height">
-                        Altura em metros
+                        Altura
                     </label>
                     <div class="input-field">
                         <i class="fa-solid fa-ruler" style="color: #fd0896;"></i>
                         <input type="number" step="0.01" id="height" name="height" required>
                         <span>
-                            m
+                            m/cm
                         </span>
                     </div>
                 </div>


### PR DESCRIPTION
## Título: Adiciona Suporte para Centímetros na Calculadora de IMC

### Contexto:
Ao utilizar a calculadora de IMC, percebi que não havia suporte para inserir a altura em centímetros, o que poderia ser mais conveniente para alguns usuários. Esta PR aborda essa limitação, permitindo que os usuários forneçam a altura em centímetros ao calcular o IMC.

### Solução:
Implementei suporte para entrada de altura em centímetros na calculadora de IMC. Agora, os usuários têm a opção de escolher entre centímetros e metros para inserir a altura.

### Principais Mudanças:
- Atualizado o código para processar corretamente a entrada em centímetros.
- Pequenos ajustes no texto para o usuário, indicando a opção de inserir a altura em centímetros.

### Testes Realizados:
Realizei testes para garantir que as alterações não afetassem a funcionalidade existente da calculadora de IMC. Todos os testes passaram com sucesso.

### Screenshot:
![image](https://github.com/Brwnds/IMC-CALCULADORA/assets/146891396/b7239861-3509-47b2-bc0b-ad92499fc6b5)